### PR TITLE
Fixed the abnormal rendering of `SpriteRenderer` in `Sliced` mode

### DIFF
--- a/packages/core/src/2d/assembler/SlicedSpriteAssembler.ts
+++ b/packages/core/src/2d/assembler/SlicedSpriteAssembler.ts
@@ -33,8 +33,8 @@ export class SlicedSpriteAssembler {
     const { width: expectWidth, height: expectHeight } = sprite;
     const fixedLeft = expectWidth * border.x;
     const fixedBottom = expectHeight * border.y;
-    const fixedRight = expectHeight * border.z;
-    const fixedTop = expectWidth * border.w;
+    const fixedRight = expectWidth * border.z;
+    const fixedTop = expectHeight * border.w;
 
     // ------------------------
     //     [3]


### PR DESCRIPTION
Width and height settings are wrong.