### PR TITLE
`ModelMesh` support custom vertex element and glTF support `KHR_mesh_quantization` extension

### DIFF
--- a/packages/core/src/graphic/Mesh.ts
+++ b/packages/core/src/graphic/Mesh.ts
@@ -18,9 +18,13 @@ export abstract class Mesh extends RefObject {
   /** Name. */
   name: string;
 
+  /** @internal */
   _vertexElementMap: Record<string, VertexElement> = {};
+  /** @internal */
   _glIndexType: number;
+  /** @internal */
   _glIndexByteCount: number;
+  /** @internal */
   _platformPrimitive: IPlatformPrimitive;
 
   /** @internal */
@@ -149,6 +153,16 @@ export abstract class Mesh extends RefObject {
     const { semantic } = element;
     this._vertexElementMap[semantic] = element;
     this._vertexElements.push(element);
+    this._updateFlagManager.dispatch(MeshModifyFlags.VertexElements);
+  }
+
+  /**
+   * @internal
+   */
+  _insertVertexElement(i: number, element: VertexElement): void {
+    const { semantic } = element;
+    this._vertexElementMap[semantic] = element;
+    this._vertexElements.splice(i, 0, element);
     this._updateFlagManager.dispatch(MeshModifyFlags.VertexElements);
   }
 

--- a/packages/core/src/mesh/BlendShapeManager.ts
+++ b/packages/core/src/mesh/BlendShapeManager.ts
@@ -43,11 +43,13 @@ export class BlendShapeManager {
   _vertices: Float32Array;
   /** @internal */
   _uniformOccupiesCount: number = 0;
+  /** @internal */
+  _vertexElementOffset: number;
 
   private _useBlendNormal: boolean = false;
   private _useBlendTangent: boolean = false;
   private _vertexElementCount: number = 0;
-  private _vertexElementOffset: number;
+
   private _storeInVertexBufferInfo: Vector2[] = [];
   private _maxCountSingleVertexBuffer: number = 0;
   private readonly _engine: Engine;
@@ -197,7 +199,6 @@ export class BlendShapeManager {
    */
   _addVertexElements(modelMesh: ModelMesh): void {
     let offset = 0;
-    this._vertexElementOffset = modelMesh._vertexElements.length;
     for (let i = 0, n = Math.min(this._blendShapeCount, this._getVertexBufferModeSupportCount()); i < n; i++) {
       modelMesh._addVertexElement(new VertexElement(`POSITION_BS${i}`, offset, VertexElementFormat.Vector3, 1));
       offset += 12;

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -33,7 +33,6 @@ export class ModelMesh extends Mesh {
   private _indices: Uint8Array | Uint16Array | Uint32Array | null = null;
   private _indicesFormat: IndexFormat = null;
   private _indicesChangeFlag: boolean = false;
-  private _vertexCountChanged: boolean = false;
 
   private _positions: Vector3[] | null = null;
   private _normals: Vector3[] | null = null;
@@ -55,6 +54,7 @@ export class ModelMesh extends Mesh {
   private _vertexDataUpdateFlag: number = 0;
   private _vertexElementsUpdate: boolean = false;
   private _customVertexElements: VertexElement[] = [];
+  private _vertexCountChanged: boolean = false;
 
   /**
    * Whether to access data of the mesh.

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -646,6 +646,7 @@ export class ModelMesh extends Mesh {
 
   /**
    * @todo Use this way to update gpu buffer should can get cpu data(may be should support get data form GPU).
+   * @use `setPosition` and `setVertexBufferBinding` at the same time, thew VertexBufferBinding and Vertex buffer data should right.
    */
   setVertexBufferBinding(
     bufferOrBinding: Buffer | VertexBufferBinding,

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -645,6 +645,7 @@ export class ModelMesh extends Mesh {
   setVertexBufferBinding(vertexBuffer: Buffer, stride: number, index?: number): void;
 
   /**
+   * @beta
    * @todo Use this way to update gpu buffer should can get cpu data(may be should support get data form GPU).
    * @use `setPosition` and `setVertexBufferBinding` at the same time, thew VertexBufferBinding and Vertex buffer data should right.
    */

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -88,8 +88,7 @@ export class ModelMesh extends Mesh {
    */
   get vertexElements(): Readonly<VertexElement[]> {
     this._updateVertexElements();
-    // @todo: this will cause GC
-    return this._vertexElements.slice(0, this._blendShapeManager._vertexElementOffset);
+    return this._vertexElements;
   }
 
   /**
@@ -723,7 +722,6 @@ export class ModelMesh extends Mesh {
       throw "Not allowed to access data while accessible is false.";
     }
 
-    const { _vertexCount: vertexCount } = this;
     this._updateVertexElements();
 
     // Vertex count change
@@ -734,7 +732,7 @@ export class ModelMesh extends Mesh {
 
       const elementCount = this._bufferStrides[0] / 4;
 
-      const vertexFloatCount = elementCount * vertexCount;
+      const vertexFloatCount = elementCount * this.vertexCount;
       const vertices = new Float32Array(vertexFloatCount);
       this._verticesFloat32 = vertices;
       this._verticesUint8 = new Uint8Array(vertices.buffer);

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -138,7 +138,7 @@ export class ModelMesh extends Mesh {
       return;
     }
 
-    const newVertexCount = positions ? positions.length : 0;
+    const newVertexCount = positions?.length || 0;
     this._vertexCountChanged = this._vertexCount != newVertexCount;
     this._vertexCount = newVertexCount;
 

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -582,7 +582,7 @@ export class ModelMesh extends Mesh {
     }
 
     const { _blendShapeManager: blendShapeManager } = this;
-    blendShapeManager._blendShapeCount > 0 && blendShapeManager._update(vertexCountChange, noLongerAccessible);
+    blendShapeManager._blendShapeCount > 0 && blendShapeManager._update(this._vertexCountChanged, noLongerAccessible);
 
     if (noLongerAccessible) {
       this._accessible = false;

--- a/packages/core/src/mesh/ModelMesh.ts
+++ b/packages/core/src/mesh/ModelMesh.ts
@@ -970,18 +970,18 @@ export class ModelMesh extends Mesh {
     const vertexElements = this._vertexElements;
 
     let i = 0;
-    let byteOffset = 0;
+    let lastOffset = 0;
     for (let n = vertexElements.length; i < n; i++) {
       const vertexElement = vertexElements[i];
       if (vertexElement.bindingIndex == 0) {
-        if (vertexElement.offset - byteOffset < needByteLength) {
+        if (vertexElement.offset - lastOffset >= needByteLength) {
           break;
         }
-        byteOffset = vertexElement.offset + this._getAttributeByteLength(vertexElement.semantic);
+        lastOffset = vertexElement.offset + this._getAttributeByteLength(vertexElement.semantic);
       }
     }
-    this._insertVertexElement(i, new VertexElement(vertexAttribute, byteOffset, format, 0));
-    this._bufferStrides[0] = byteOffset + needByteLength;
+    this._insertVertexElement(i, new VertexElement(vertexAttribute, lastOffset, format, 0));
+    this._bufferStrides[0] = lastOffset + needByteLength;
   }
 
   private _getAttributeFormat(attribute: VertexAttribute): VertexElementFormat {

--- a/packages/core/src/mesh/enums/VertexAttribute.ts
+++ b/packages/core/src/mesh/enums/VertexAttribute.ts
@@ -1,0 +1,33 @@
+/**
+ * Vertex attribute types of a vertex in a ModelMesh.
+ */
+export enum VertexAttribute {
+  /** Vertex position. */
+  Position = "POSITION",
+  /** Vertex normal. */
+  Normal = "NORMAL",
+  /** Vertex color. */
+  Color = "COLOR_0",
+  /** Vertex tangent. */
+  Tangent = "TANGENT",
+  /** Vertex bone weight. */
+  BoneWeight = "WEIGHTS_0",
+  /** Vertex bone index. */
+  BoneIndex = "JOINTS_0",
+  /** Vertex UV. */
+  UV = "TEXCOORD_0",
+  /** Vertex UV1. */
+  UV1 = "TEXCOORD_1",
+  /** Vertex UV2. */
+  UV2 = "TEXCOORD_2",
+  /** Vertex UV3. */
+  UV3 = "TEXCOORD_3",
+  /** Vertex UV4. */
+  UV4 = "TEXCOORD_4",
+  /** Vertex UV5. */
+  UV5 = "TEXCOORD_5",
+  /** Vertex UV6. */
+  UV6 = "TEXCOORD_6",
+  /** Vertex UV7. */
+  UV7 = "TEXCOORD_7"
+}

--- a/packages/loader/src/gltf/GLTFUtil.ts
+++ b/packages/loader/src/gltf/GLTFUtil.ts
@@ -130,6 +130,22 @@ export class GLTFUtil {
     }
   }
 
+  static getNormalizedComponentScale(componentType: AccessorComponentType) {
+    // Reference: https://github.com/KhronosGroup/glTF/tree/master/extensions/2.0/Khronos/KHR_mesh_quantization#encoding-quantized-data
+    switch (componentType) {
+      case AccessorComponentType.BYTE:
+        return 1 / 127;
+      case AccessorComponentType.UNSIGNED_BYTE:
+        return 1 / 255;
+      case AccessorComponentType.SHORT:
+        return 1 / 32767;
+      case AccessorComponentType.UNSIGNED_SHORT:
+        return 1 / 65535;
+      default:
+        throw new Error("Oasis.GLTFLoader: Unsupported normalized accessor component type.");
+    }
+  }
+
   /**
    * Get accessor data.
    */

--- a/packages/loader/src/gltf/GLTFUtil.ts
+++ b/packages/loader/src/gltf/GLTFUtil.ts
@@ -220,52 +220,43 @@ export class GLTFUtil {
   /**
    * Get accessor data.
    */
-  static getVertexAccessorData(gltf: IGLTF, accessor: IAccessor, buffers: ArrayBuffer[]): TypedArray {
+  static processingSparseData(
+    gltf: IGLTF,
+    accessor: IAccessor,
+    buffers: ArrayBuffer[],
+    originData: TypedArray
+  ): TypedArray {
     const bufferViews = gltf.bufferViews;
-    const bufferView = bufferViews[accessor.bufferView];
-    const arrayBuffer = buffers[bufferView.buffer];
-    const bufferViewByteOffset = bufferView.hasOwnProperty("byteOffset") ? bufferView.byteOffset : 0;
-    const accessorByteOffset = accessor.hasOwnProperty("byteOffset") ? accessor.byteOffset : 0;
-    const byteOffset = bufferViewByteOffset + accessorByteOffset;
     const accessorTypeSize = GLTFUtil.getAccessorTypeSize(accessor.type);
-    const byteStride = bufferView.byteStride;
     const TypedArray = GLTFUtil.getComponentType(accessor.componentType);
+    const data = originData.slice();
 
-    let data: TypedArray;
-    if (byteStride && byteStride !== accessorTypeSize * TypedArray.BYTES_PER_ELEMENT) {
-      data = new TypedArray(arrayBuffer, byteOffset, accessor.count * (byteStride / TypedArray.BYTES_PER_ELEMENT));
-    } else {
-      data = new TypedArray(arrayBuffer, byteOffset, accessor.count * accessorTypeSize);
-    }
+    const { count, indices, values } = accessor.sparse;
+    const indicesBufferView = bufferViews[indices.bufferView];
+    const valuesBufferView = bufferViews[values.bufferView];
+    const indicesArrayBuffer = buffers[indicesBufferView.buffer];
+    const valuesArrayBuffer = buffers[valuesBufferView.buffer];
+    const indicesByteOffset = (indices.byteOffset ?? 0) + (indicesBufferView.byteOffset ?? 0);
+    const indicesByteLength = indicesBufferView.byteLength;
+    const valuesByteOffset = (values.byteOffset ?? 0) + (valuesBufferView.byteOffset ?? 0);
+    const valuesByteLength = valuesBufferView.byteLength;
 
-    if (accessor.sparse) {
-      const { count, indices, values } = accessor.sparse;
-      const indicesBufferView = bufferViews[indices.bufferView];
-      const valuesBufferView = bufferViews[values.bufferView];
-      const indicesArrayBuffer = buffers[indicesBufferView.buffer];
-      const valuesArrayBuffer = buffers[valuesBufferView.buffer];
-      const indicesByteOffset = (indices.byteOffset ?? 0) + (indicesBufferView.byteOffset ?? 0);
-      const indicesByteLength = indicesBufferView.byteLength;
-      const valuesByteOffset = (values.byteOffset ?? 0) + (valuesBufferView.byteOffset ?? 0);
-      const valuesByteLength = valuesBufferView.byteLength;
+    const IndexTypeArray = GLTFUtil.getComponentType(indices.componentType);
+    const indicesArray = new IndexTypeArray(
+      indicesArrayBuffer,
+      indicesByteOffset,
+      indicesByteLength / IndexTypeArray.BYTES_PER_ELEMENT
+    );
+    const valuesArray = new TypedArray(
+      valuesArrayBuffer,
+      valuesByteOffset,
+      valuesByteLength / TypedArray.BYTES_PER_ELEMENT
+    );
 
-      const indicesType = GLTFUtil.getComponentType(indices.componentType);
-      const indicesArray = new indicesType(
-        indicesArrayBuffer,
-        indicesByteOffset,
-        indicesByteLength / indicesType.BYTES_PER_ELEMENT
-      );
-      const valuesArray = new TypedArray(
-        valuesArrayBuffer,
-        valuesByteOffset,
-        valuesByteLength / TypedArray.BYTES_PER_ELEMENT
-      );
-
-      for (let i = 0; i < count; i++) {
-        const replaceIndex = indicesArray[i];
-        for (let j = 0; j < accessorTypeSize; j++) {
-          data[replaceIndex * accessorTypeSize + j] = valuesArray[i * accessorTypeSize + j];
-        }
+    for (let i = 0; i < count; i++) {
+      const replaceIndex = indicesArray[i];
+      for (let j = 0; j < accessorTypeSize; j++) {
+        data[replaceIndex * accessorTypeSize + j] = valuesArray[i * accessorTypeSize + j];
       }
     }
 

--- a/packages/loader/src/gltf/GLTFUtil.ts
+++ b/packages/loader/src/gltf/GLTFUtil.ts
@@ -1,4 +1,4 @@
-import { IndexFormat, TypedArray, VertexElement, VertexElementFormat } from "@oasis-engine/core";
+import { IndexFormat, TypedArray, VertexElementFormat } from "@oasis-engine/core";
 import { Color, Vector2, Vector3, Vector4 } from "@oasis-engine/math";
 import { AccessorComponentType, AccessorType, IAccessor, IBufferView, IGLTF } from "./Schema";
 
@@ -281,16 +281,6 @@ export class GLTFUtil {
     const size = GLTFUtil.getAccessorTypeSize(accessor.type);
     const componentType = GLTFUtil.getComponentType(accessor.componentType);
     return size * componentType.BYTES_PER_ELEMENT;
-  }
-
-  static createVertexElement(semantic: string, accessor: IAccessor, index: number): VertexElement {
-    const size = GLTFUtil.getAccessorTypeSize(accessor.type);
-    return new VertexElement(
-      semantic,
-      0,
-      GLTFUtil.getElementFormat(accessor.componentType, size, accessor.normalized),
-      index
-    );
   }
 
   static getIndexFormat(type: AccessorComponentType): IndexFormat {

--- a/packages/loader/src/gltf/GLTFUtil.ts
+++ b/packages/loader/src/gltf/GLTFUtil.ts
@@ -229,13 +229,13 @@ export class GLTFUtil {
     const byteOffset = bufferViewByteOffset + accessorByteOffset;
     const accessorTypeSize = GLTFUtil.getAccessorTypeSize(accessor.type);
     const byteStride = bufferView.byteStride;
-    const arrayType = GLTFUtil.getComponentType(accessor.componentType);
+    const TypedArray = GLTFUtil.getComponentType(accessor.componentType);
 
-    let typedArray: TypedArray;
-    if (byteStride && byteStride !== accessorTypeSize * arrayType.BYTES_PER_ELEMENT) {
-      typedArray = new arrayType(arrayBuffer, byteOffset, accessor.count * (byteStride / arrayType.BYTES_PER_ELEMENT));
+    let data: TypedArray;
+    if (byteStride && byteStride !== accessorTypeSize * TypedArray.BYTES_PER_ELEMENT) {
+      data = new TypedArray(arrayBuffer, byteOffset, accessor.count * (byteStride / TypedArray.BYTES_PER_ELEMENT));
     } else {
-      typedArray = new arrayType(arrayBuffer, byteOffset, accessor.count * accessorTypeSize);
+      data = new TypedArray(arrayBuffer, byteOffset, accessor.count * accessorTypeSize);
     }
 
     if (accessor.sparse) {
@@ -255,21 +255,21 @@ export class GLTFUtil {
         indicesByteOffset,
         indicesByteLength / indicesType.BYTES_PER_ELEMENT
       );
-      const valuesArray = new arrayType(
+      const valuesArray = new TypedArray(
         valuesArrayBuffer,
         valuesByteOffset,
-        valuesByteLength / arrayType.BYTES_PER_ELEMENT
+        valuesByteLength / TypedArray.BYTES_PER_ELEMENT
       );
 
       for (let i = 0; i < count; i++) {
         const replaceIndex = indicesArray[i];
         for (let j = 0; j < accessorTypeSize; j++) {
-          typedArray[replaceIndex * accessorTypeSize + j] = valuesArray[i * accessorTypeSize + j];
+          data[replaceIndex * accessorTypeSize + j] = valuesArray[i * accessorTypeSize + j];
         }
       }
     }
 
-    return typedArray;
+    return data;
   }
 
   static getVertexStride(gltf: IGLTF, accessor: IAccessor): number {

--- a/packages/loader/src/gltf/GLTFUtil.ts
+++ b/packages/loader/src/gltf/GLTFUtil.ts
@@ -263,17 +263,6 @@ export class GLTFUtil {
     return data;
   }
 
-  static getVertexStride(gltf: IGLTF, accessor: IAccessor): number {
-    const stride = gltf.bufferViews[accessor.bufferView ?? 0].byteStride;
-    if (stride) {
-      return stride;
-    }
-
-    const size = GLTFUtil.getAccessorTypeSize(accessor.type);
-    const componentType = GLTFUtil.getComponentType(accessor.componentType);
-    return size * componentType.BYTES_PER_ELEMENT;
-  }
-
   static getIndexFormat(type: AccessorComponentType): IndexFormat {
     switch (type) {
       case AccessorComponentType.UNSIGNED_BYTE:

--- a/packages/loader/src/gltf/parser/MeshParser.ts
+++ b/packages/loader/src/gltf/parser/MeshParser.ts
@@ -154,15 +154,13 @@ export class MeshParser extends Parser {
       mesh.setVertexBufferBinding(vertexBuffer, stride, i++);
 
       if (attributeSemantic === "POSITION") {
-        const { bounds } = mesh;
+        const { min, max } = mesh.bounds;
         vertexCount = accessor.count;
         if (accessor.min && accessor.max) {
-          bounds.min.copyFromArray(accessor.min);
-          bounds.max.copyFromArray(accessor.max);
+          min.copyFromArray(accessor.min);
+          max.copyFromArray(accessor.max);
         } else {
           const position = MeshParser._tempVector3;
-          const { min, max } = bounds;
-
           min.set(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
           max.set(-Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE);
 
@@ -173,6 +171,12 @@ export class MeshParser extends Parser {
             Vector3.min(min, position, min);
             Vector3.max(max, position, max);
           }
+        }
+
+        if (accessor.normalized) {
+          const sacleFactor = GLTFUtil.getNormalizedComponentScale(accessor.componentType);
+          min.scale(sacleFactor);
+          max.scale(sacleFactor);
         }
       }
     }

--- a/packages/loader/src/gltf/parser/MeshParser.ts
+++ b/packages/loader/src/gltf/parser/MeshParser.ts
@@ -85,9 +85,7 @@ export class MeshParser extends Parser {
               gltfPrimitive,
               gltf,
               (attributeSemantic) => {
-                const accessorIdx = gltfPrimitive.attributes[attributeSemantic];
-                const accessor = gltf.accessors[accessorIdx];
-                return GLTFUtil.getVertexAccessorData(gltf, accessor, buffers);
+                return null;
               },
               (attributeName, shapeIndex) => {
                 const shapeAccessorIdx = gltfPrimitive.targets[shapeIndex];
@@ -204,11 +202,8 @@ export class MeshParser extends Parser {
       }
       vertexElements.push(vertexElement);
 
-      if (accessor.sparse) {
-        throw "error";
-      }
-
       if (attribute === "POSITION") {
+        vertexCount = attributeCount;
         const { min, max } = mesh.bounds;
         if (accessor.min && accessor.max) {
           min.copyFromArray(accessor.min);

--- a/packages/loader/src/gltf/parser/MeshParser.ts
+++ b/packages/loader/src/gltf/parser/MeshParser.ts
@@ -54,6 +54,7 @@ export class MeshParser extends Parser {
             ))
               .then((decodedGeometry: any) => {
                 return this._parseMeshFromGLTFPrimitive(
+                  context,
                   mesh,
                   gltfMesh,
                   gltfPrimitive,
@@ -78,6 +79,7 @@ export class MeshParser extends Parser {
               .then(resolve);
           } else {
             this._parseMeshFromGLTFPrimitive(
+              context,
               mesh,
               gltfMesh,
               gltfPrimitive,
@@ -124,6 +126,7 @@ export class MeshParser extends Parser {
   }
 
   private _parseMeshFromGLTFPrimitive(
+    context: ParserContext,
     mesh: ModelMesh,
     gltfMesh: IMesh,
     gltfPrimitive: IMeshPrimitive,
@@ -134,28 +137,73 @@ export class MeshParser extends Parser {
     keepMeshData: boolean
   ): Promise<ModelMesh> {
     const { accessors } = gltf;
+    const { buffers } = context.glTFResource;
     const { attributes, targets, indices, mode } = gltfPrimitive;
 
     const engine = mesh.engine;
     const vertexElements = new Array<VertexElement>();
+    const bufferViews = gltf.bufferViews;
 
     let vertexCount: number;
-    let i = 0;
-    for (const attributeSemantic in attributes) {
-      const accessorIdx = attributes[attributeSemantic];
-      const accessor = accessors[accessorIdx];
-      const stride = GLTFUtil.getVertexStride(gltf, accessor);
-      const vertexELement = GLTFUtil.createVertexElement(attributeSemantic, accessor, i);
-      vertexElements.push(vertexELement);
+    let bufferBindIndex = 0;
+    for (const attribute in attributes) {
+      const accessor = accessors[attributes[attribute]];
+      const componentType = accessor.componentType;
+      const bufferView = bufferViews[accessor.bufferView];
 
-      const bufferData = getVertexBufferData(attributeSemantic);
-      const vertexBuffer = new Buffer(engine, BufferBindFlag.VertexBuffer, bufferData.byteLength, BufferUsage.Static);
-      vertexBuffer.setData(bufferData);
-      mesh.setVertexBufferBinding(vertexBuffer, stride, i++);
+      const buffer = buffers[bufferView.buffer];
+      const bufferByteOffset = bufferView.byteOffset || 0;
+      const bufferStride = bufferView.byteStride;
+      const byteOffset = accessor.byteOffset || 0;
 
-      if (attributeSemantic === "POSITION") {
+      const TypedArray = GLTFUtil.getComponentType(componentType);
+      const dataElmentSize = GLTFUtil.getAccessorTypeSize(accessor.type);
+      const dataElementBytes = TypedArray.BYTES_PER_ELEMENT;
+      const elementStride = dataElmentSize * dataElementBytes;
+      const attributeCount = accessor.count;
+
+      let vertexElement: VertexElement;
+      let vertices: TypedArray;
+      const elementFormat = GLTFUtil.getElementFormat(componentType, dataElmentSize, accessor.normalized);
+      if (bufferStride && bufferStride !== elementStride) {
+        const bufferSlice = Math.floor(byteOffset / bufferStride);
+        const bufferCacheKey = accessor.bufferView + ":" + componentType + ":" + bufferSlice + ":" + attributeCount;
+        const cacheBuffer = context.vertexBufferCache[bufferCacheKey];
+
+        const elementOffset = byteOffset % bufferStride;
+        if (!cacheBuffer) {
+          vertexElement = new VertexElement(attribute, elementOffset, elementFormat, bufferBindIndex);
+
+          const offset = bufferByteOffset + bufferSlice * bufferStride;
+          const count = attributeCount * (bufferStride / dataElementBytes);
+          vertices = new TypedArray(buffer, offset, count);
+
+          const vertexBuffer = new Buffer(engine, BufferBindFlag.VertexBuffer, vertices.byteLength, BufferUsage.Static);
+          vertexBuffer.setData(vertices);
+          mesh.setVertexBufferBinding(vertexBuffer, bufferStride, bufferBindIndex);
+
+          context.vertexBufferCache[bufferCacheKey] = { bindIndex: bufferBindIndex++, buffer: vertexBuffer };
+        } else {
+          vertexElement = new VertexElement(attribute, elementOffset, elementFormat, cacheBuffer.bindIndex);
+        }
+      } else {
+        vertexElement = new VertexElement(attribute, 0, elementFormat, bufferBindIndex);
+        const offset = bufferByteOffset + byteOffset;
+        const count = attributeCount * dataElmentSize;
+        vertices = new TypedArray(buffer, offset, count);
+
+        const vertexBuffer = new Buffer(engine, BufferBindFlag.VertexBuffer, vertices.byteLength, BufferUsage.Static);
+        vertexBuffer.setData(vertices);
+        mesh.setVertexBufferBinding(vertexBuffer, elementStride, bufferBindIndex++);
+      }
+      vertexElements.push(vertexElement);
+
+      if (accessor.sparse) {
+        throw "error";
+      }
+
+      if (attribute === "POSITION") {
         const { min, max } = mesh.bounds;
-        vertexCount = accessor.count;
         if (accessor.min && accessor.max) {
           min.copyFromArray(accessor.min);
           max.copyFromArray(accessor.max);
@@ -164,10 +212,10 @@ export class MeshParser extends Parser {
           min.set(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
           max.set(-Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE);
 
-          const stride = bufferData.length / vertexCount;
-          for (let j = 0; j < vertexCount; j++) {
+          const stride = vertices.length / attributeCount;
+          for (let j = 0; j < attributeCount; j++) {
             const offset = j * stride;
-            position.copyFromArray(bufferData, offset);
+            position.copyFromArray(vertices, offset);
             Vector3.min(min, position, min);
             Vector3.max(max, position, max);
           }

--- a/packages/loader/src/gltf/parser/MeshParser.ts
+++ b/packages/loader/src/gltf/parser/MeshParser.ts
@@ -85,7 +85,7 @@ export class MeshParser extends Parser {
               (attributeSemantic) => {
                 const accessorIdx = gltfPrimitive.attributes[attributeSemantic];
                 const accessor = gltf.accessors[accessorIdx];
-                return GLTFUtil.getAccessorData(gltf, accessor, buffers);
+                return GLTFUtil.getVertexAccessorData(gltf, accessor, buffers);
               },
               (attributeName, shapeIndex) => {
                 const shapeAccessorIdx = gltfPrimitive.targets[shapeIndex];

--- a/packages/loader/src/gltf/parser/MeshParser.ts
+++ b/packages/loader/src/gltf/parser/MeshParser.ts
@@ -10,7 +10,7 @@ import {
 } from "@oasis-engine/core";
 import { Vector3 } from "@oasis-engine/math";
 import { GLTFUtil } from "../GLTFUtil";
-import { IGLTF, IMesh, IMeshPrimitive } from "../Schema";
+import { AccessorType, IGLTF, IMesh, IMeshPrimitive } from "../Schema";
 import { Parser } from "./Parser";
 import { ParserContext } from "./ParserContext";
 
@@ -53,8 +53,7 @@ export class MeshParser extends Parser {
               )
             ))
               .then((decodedGeometry: any) => {
-                return this._parseMeshFromGLTFPrimitive(
-                  context,
+                return this._parseMeshFromGLTFPrimitiveDraco(
                   mesh,
                   gltfMesh,
                   gltfPrimitive,
@@ -271,5 +270,133 @@ export class MeshParser extends Parser {
       blendShape.addFrame(1.0, deltaPositions, deltaNormals, deltaTangents);
       mesh.addBlendShape(blendShape);
     }
+  }
+
+  /**
+   * @deprecated
+   */
+  private _parseMeshFromGLTFPrimitiveDraco(
+    mesh: ModelMesh,
+    gltfMesh: IMesh,
+    gltfPrimitive: IMeshPrimitive,
+    gltf: IGLTF,
+    getVertexBufferData: (semantic: string) => TypedArray,
+    getBlendShapeData: (semantic: string, shapeIndex: number) => TypedArray,
+    getIndexBufferData: () => TypedArray,
+    keepMeshData: boolean
+  ): Promise<ModelMesh> {
+    const { attributes, targets, indices, mode } = gltfPrimitive;
+    let vertexCount: number;
+
+    const { accessors } = gltf;
+    const accessor = accessors[attributes["POSITION"]];
+    const positionBuffer = <Float32Array>getVertexBufferData("POSITION");
+    const positions = GLTFUtil.floatBufferToVector3Array(positionBuffer);
+    mesh.setPositions(positions);
+
+    const { bounds } = mesh;
+    vertexCount = accessor.count;
+    if (accessor.min && accessor.max) {
+      bounds.min.copyFromArray(accessor.min);
+      bounds.max.copyFromArray(accessor.max);
+    } else {
+      const position = MeshParser._tempVector3;
+      const { min, max } = bounds;
+
+      min.set(Number.MAX_VALUE, Number.MAX_VALUE, Number.MAX_VALUE);
+      max.set(-Number.MAX_VALUE, -Number.MAX_VALUE, -Number.MAX_VALUE);
+
+      const stride = positionBuffer.length / vertexCount;
+      for (let j = 0; j < vertexCount; j++) {
+        const offset = j * stride;
+        position.copyFromArray(positionBuffer, offset);
+        Vector3.min(min, position, min);
+        Vector3.max(max, position, max);
+      }
+    }
+
+    for (const attributeSemantic in attributes) {
+      if (attributeSemantic === "POSITION") {
+        continue;
+      }
+      const bufferData = getVertexBufferData(attributeSemantic);
+      switch (attributeSemantic) {
+        case "NORMAL":
+          const normals = GLTFUtil.floatBufferToVector3Array(<Float32Array>bufferData);
+          mesh.setNormals(normals);
+          break;
+        case "TEXCOORD_0":
+          const texturecoords = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
+          mesh.setUVs(texturecoords, 0);
+          break;
+        case "TEXCOORD_1":
+          const texturecoords1 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
+          mesh.setUVs(texturecoords1, 1);
+          break;
+        case "TEXCOORD_2":
+          const texturecoords2 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
+          mesh.setUVs(texturecoords2, 2);
+          break;
+        case "TEXCOORD_3":
+          const texturecoords3 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
+          mesh.setUVs(texturecoords3, 3);
+          break;
+        case "TEXCOORD_4":
+          const texturecoords4 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
+          mesh.setUVs(texturecoords4, 4);
+          break;
+        case "TEXCOORD_5":
+          const texturecoords5 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
+          mesh.setUVs(texturecoords5, 5);
+          break;
+        case "TEXCOORD_6":
+          const texturecoords6 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
+          mesh.setUVs(texturecoords6, 6);
+          break;
+        case "TEXCOORD_7":
+          const texturecoords7 = GLTFUtil.floatBufferToVector2Array(<Float32Array>bufferData);
+          mesh.setUVs(texturecoords7, 7);
+          break;
+        case "COLOR_0":
+          const colors = GLTFUtil.floatBufferToColorArray(
+            <Float32Array>bufferData,
+            accessors[attributes["COLOR_0"]].type === AccessorType.VEC3
+          );
+          mesh.setColors(colors);
+          break;
+        case "TANGENT":
+          const tangents = GLTFUtil.floatBufferToVector4Array(<Float32Array>bufferData);
+          mesh.setTangents(tangents);
+          break;
+
+        case "JOINTS_0":
+          const joints = GLTFUtil.floatBufferToVector4Array(<Float32Array>bufferData);
+          mesh.setBoneIndices(joints);
+          break;
+        case "WEIGHTS_0":
+          const weights = GLTFUtil.floatBufferToVector4Array(<Float32Array>bufferData);
+          mesh.setBoneWeights(weights);
+          break;
+        default:
+          // console.warn(`Unsupport attribute semantic ${attributeSemantic}.`);
+          break;
+      }
+    }
+
+    // Indices
+    if (indices !== undefined) {
+      const indexAccessor = gltf.accessors[indices];
+      const indexData = getIndexBufferData();
+      mesh.setIndices(<Uint8Array | Uint16Array | Uint32Array>indexData);
+      mesh.addSubMesh(0, indexAccessor.count, mode);
+    } else {
+      mesh.addSubMesh(0, vertexCount, mode);
+    }
+
+    // BlendShapes
+    targets && this._createBlendShape(mesh, gltfMesh, targets, getBlendShapeData);
+
+    mesh.uploadData(!keepMeshData);
+    return Promise.resolve(mesh);
   }
 }

--- a/packages/loader/src/gltf/parser/MeshParser.ts
+++ b/packages/loader/src/gltf/parser/MeshParser.ts
@@ -177,6 +177,9 @@ export class MeshParser extends Parser {
           const offset = bufferByteOffset + bufferSlice * bufferStride;
           const count = attributeCount * (bufferStride / dataElementBytes);
           vertices = new TypedArray(buffer, offset, count);
+          if (accessor.sparse) {
+            vertices = GLTFUtil.processingSparseData(gltf, accessor, buffers, vertices);
+          }
 
           const vertexBuffer = new Buffer(engine, BufferBindFlag.VertexBuffer, vertices.byteLength, BufferUsage.Static);
           vertexBuffer.setData(vertices);
@@ -191,6 +194,9 @@ export class MeshParser extends Parser {
         const offset = bufferByteOffset + byteOffset;
         const count = attributeCount * dataElmentSize;
         vertices = new TypedArray(buffer, offset, count);
+        if (accessor.sparse) {
+          vertices = GLTFUtil.processingSparseData(gltf, accessor, buffers, vertices);
+        }
 
         const vertexBuffer = new Buffer(engine, BufferBindFlag.VertexBuffer, vertices.byteLength, BufferUsage.Static);
         vertexBuffer.setData(vertices);

--- a/packages/loader/src/gltf/parser/ParserContext.ts
+++ b/packages/loader/src/gltf/parser/ParserContext.ts
@@ -1,3 +1,4 @@
+import { Buffer, VertexBufferBinding } from "@oasis-engine/core";
 import { GLTFResource } from "../GLTFResource";
 
 /**
@@ -14,4 +15,6 @@ export class ParserContext {
   meshIndex?: number;
   subMeshIndex?: number;
   defaultSceneRootOnly?: boolean;
+
+  vertexBufferCache: Record<string, { bindIndex: number; buffer: Buffer }> = {};
 }

--- a/packages/rhi-webgl/src/GLPrimitive.ts
+++ b/packages/rhi-webgl/src/GLPrimitive.ts
@@ -113,6 +113,7 @@ export class GLPrimitive implements IPlatformPrimitive {
 
     this.attribLocArray.length = 0;
     const attributeLocation = shaderProgram.attributeLocation;
+    // @ts-ignore
     const attributes = primitive._vertexElementMap;
 
     let vbo: WebGLBuffer;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

### What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)
- `ModelMesh` add custom vertex element and custom vertex buffer support "low level API"
-  glTF support `KHR_mesh_quantization` extension

### Notes
This PR is a special case. It only ensures that ModelMesh can use "low level API" and "high level API".  
Mixed use is not supported now.
**Later todo:**
- `ModelMesh` supports mixed use of high-level API and low-level API
- Redesign `ModelMesh` low-level API 
- Refactor glTF draco laoder