### PR TITLE
Improve skinned mesh renderer local bounds compute

### DIFF
--- a/packages/core/src/mesh/SkinnedMeshRenderer.ts
+++ b/packages/core/src/mesh/SkinnedMeshRenderer.ts
@@ -279,8 +279,7 @@ export class SkinnedMeshRenderer extends MeshRenderer {
       const inverseBindMatrices = skin.inverseBindMatrices;
       const rootBoneChildren = rootBone.children;
       for (let i = 0; i < jointCount; i++) {
-        const child = rootBoneChildren[i];
-        const index = jointEntitys.indexOf(child);
+        const index = jointEntitys.indexOf(rootBoneChildren[i]);
         if (index !== -1) {
           Matrix.add(approximateBindMatrix, inverseBindMatrices[index], approximateBindMatrix);
           subRootBoneCount++;

--- a/packages/math/src/Matrix.ts
+++ b/packages/math/src/Matrix.ts
@@ -143,6 +143,62 @@ export class Matrix implements IClone<Matrix>, ICopy<Matrix, Matrix> {
   }
 
   /**
+   * Determines the sum of two matrices.
+   * @param left - The first matrix to add
+   * @param right - The second matrix to add
+   * @param out - The sum of two matrices
+   */
+  static add(left: Matrix, right: Matrix, out: Matrix): void {
+    const le = left.elements;
+    const re = right.elements;
+    const oe = out.elements;
+    oe[0] = le[0] + re[0];
+    oe[1] = le[1] + re[1];
+    oe[2] = le[2] + re[2];
+    oe[3] = le[3] + re[3];
+    oe[4] = le[4] + re[4];
+    oe[5] = le[5] + re[5];
+    oe[6] = le[6] + re[6];
+    oe[7] = le[7] + re[7];
+    oe[8] = le[8] + re[8];
+    oe[9] = le[9] + re[9];
+    oe[10] = le[10] + re[10];
+    oe[11] = le[11] + re[11];
+    oe[12] = le[12] + re[12];
+    oe[13] = le[13] + re[13];
+    oe[14] = le[14] + re[14];
+    oe[15] = le[15] + re[15];
+  }
+
+  /**
+   * Multiplies a matrix by a scalar.
+   * @param source - The matrix to multiply
+   * @param scalar - The scalar to multiply
+   * @param out - The result of multiplying a matrix by a scalar
+   */
+  static multiplyScalar(source: Matrix, scalar: number, out: Matrix): void {
+    const se = source.elements;
+    const oe = out.elements;
+
+    oe[0] = se[0] * scalar;
+    oe[1] = se[1] * scalar;
+    oe[2] = se[2] * scalar;
+    oe[3] = se[3] * scalar;
+    oe[4] = se[4] * scalar;
+    oe[5] = se[5] * scalar;
+    oe[6] = se[6] * scalar;
+    oe[7] = se[7] * scalar;
+    oe[8] = se[8] * scalar;
+    oe[9] = se[9] * scalar;
+    oe[10] = se[10] * scalar;
+    oe[11] = se[11] * scalar;
+    oe[12] = se[12] * scalar;
+    oe[13] = se[13] * scalar;
+    oe[14] = se[14] * scalar;
+    oe[15] = se[15] * scalar;
+  }
+
+  /**
    * Calculate a rotation matrix from a quaternion.
    * @param quaternion - The quaternion used to calculate the matrix
    * @param out - The calculated rotation matrix


### PR DESCRIPTION
If rootBone is not in inverse bind matrix list, we fall back to use inverse default pose before.

But this will cause the local bounds compute very inaccurate, especially when using `KHR_mesh_quantization`, because inverse bind matrix will contatin large scale,  inverse default pose not contain. so the bounds will hundreds of times the size.

I can't solve the exact problem, but I can solve the problem of hundreds of times difference by calculating the approximate inverse bind matrix.
