### PR TITLE
Fix `Time` delta inconsistency bug

### DIFF
--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -304,6 +304,7 @@ export class Engine extends EventDispatcher {
   update(): void {
     const time = this._time;
     time.tick();
+    
     const deltaTime = time.deltaTime;
     this._frameInProcess = true;
 

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -303,11 +303,10 @@ export class Engine extends EventDispatcher {
    */
   update(): void {
     const time = this._time;
+    time.tick();
     const deltaTime = time.deltaTime;
     this._frameInProcess = true;
-    time._frameCount++;
 
-    time.tick();
     this._renderElementPool.resetPool();
     this._spriteElementPool.resetPool();
     this._spriteMaskElementPool.resetPool();

--- a/packages/core/src/base/Time.ts
+++ b/packages/core/src/base/Time.ts
@@ -81,5 +81,6 @@ export class Time {
     const now = this.nowTime;
     this._deltaTime = (now - this._lastTickTime) * this._timeScale;
     this._lastTickTime = now;
+    ++this._frameCount;
   }
 }

--- a/packages/core/src/base/Time.ts
+++ b/packages/core/src/base/Time.ts
@@ -81,6 +81,6 @@ export class Time {
     const now = this.nowTime;
     this._deltaTime = (now - this._lastTickTime) * this._timeScale;
     this._lastTickTime = now;
-    ++this._frameCount;
+    this._frameCount++;
   }
 }


### PR DESCRIPTION
onUpdate(deltaTime) {
    // deltaTime !== engine.time.deltaTime
}