### PR TITLE
Add `platform` and `operatingSystem` for `SystemInfo` and fix ios 15 rendering error

### DIFF
--- a/packages/core/src/Platform.ts
+++ b/packages/core/src/Platform.ts
@@ -1,0 +1,13 @@
+/**
+ * The platform (including operating system and hardware) is running on.
+ */
+export enum Platform {
+  /** Android platform. */
+  Android,
+  /** IPhone platform. */
+  IPhone,
+  /** IPad platform. */
+  IPad,
+  /** Unknown platform. */
+  Unknown
+}

--- a/packages/core/src/SystemInfo.ts
+++ b/packages/core/src/SystemInfo.ts
@@ -1,7 +1,14 @@
+import { Platform } from "./Platform";
+
 /**
  * System info.
  */
 export class SystemInfo {
+  /** The platform is running on. */
+  static platform: Platform = Platform.Unknown;
+  /** The operating system is running on. */
+  static operatingSystem: string = "";
+
   /**
    * The pixel ratio of the device.
    */
@@ -12,12 +19,39 @@ export class SystemInfo {
   /**
    * @internal
    */
-  static _isIos(): boolean {
-    if (!window) {
-      return false;
-    }
+  static _initialization(): void {
+    {
+      if (typeof navigator == "undefined") {
+        return;
+      }
 
-    const ua = window.navigator.userAgent.toLocaleLowerCase();
-    return /iphone|ipad|ipod/.test(ua);
+      const userAgent = navigator.userAgent;
+
+      if (/iphone)/i.test(userAgent)) {
+        SystemInfo.platform = Platform.IPhone;
+      } else if (/ipad/i.test(userAgent)) {
+        SystemInfo.platform = Platform.IPad;
+      } else if (/android/i.test(userAgent)) {
+        SystemInfo.platform = Platform.Android;
+      }
+
+      let v: RegExpMatchArray;
+      switch (SystemInfo.platform) {
+        case Platform.IPhone:
+          v = userAgent.match(/OS (\d+)_(\d+)_?(\d+)?/);
+          this.operatingSystem = `iPhone OS ${v[1]}.${v[2]}.${v[3]}`;
+          break;
+        case Platform.IPad:
+          v = userAgent.match(/OS (\d+)_(\d+)_?(\d+)?/);
+          this.operatingSystem = `iPad OS ${v[1]}.${v[2]}.${v[3]}`;
+          break;
+        case Platform.Android:
+          v = userAgent.match(/Android (\d+).(\d+).?(\d+)?/);
+          this.operatingSystem = `Android ${v[1]}.${v[2]}.${v[3]}`;
+          break;
+      }
+    }
   }
 }
+
+SystemInfo._initialization();

--- a/packages/core/src/SystemInfo.ts
+++ b/packages/core/src/SystemInfo.ts
@@ -27,11 +27,11 @@ export class SystemInfo {
 
       const userAgent = navigator.userAgent;
 
-      if (/iphone)/i.test(userAgent)) {
+      if (/iPhone/i.test(userAgent)) {
         SystemInfo.platform = Platform.IPhone;
-      } else if (/ipad/i.test(userAgent)) {
+      } else if (/iPad/i.test(userAgent)) {
         SystemInfo.platform = Platform.IPad;
-      } else if (/android/i.test(userAgent)) {
+      } else if (/Android/i.test(userAgent)) {
         SystemInfo.platform = Platform.Android;
       }
 
@@ -39,14 +39,14 @@ export class SystemInfo {
       switch (SystemInfo.platform) {
         case Platform.IPhone:
           v = userAgent.match(/OS (\d+)_(\d+)_?(\d+)?/);
-          this.operatingSystem = `iPhone OS ${v[1]}.${v[2]}.${v[3]}`;
+          this.operatingSystem = `iPhone OS ${v[1]}.${v[2]}.${v[3] || 0}`;
           break;
         case Platform.IPad:
           v = userAgent.match(/OS (\d+)_(\d+)_?(\d+)?/);
-          this.operatingSystem = `iPad OS ${v[1]}.${v[2]}.${v[3]}`;
+          this.operatingSystem = `iPad OS ${v[1]}.${v[2]}.${v[3] || 0}`;
           break;
         case Platform.Android:
-          v = userAgent.match(/Android (\d+).(\d+).?(\d+)?/);
+          v = userAgent.match(/Android (\d+).(\d+).(\d+)/);
           this.operatingSystem = `Android ${v[1]}.${v[2]}.${v[3]}`;
           break;
       }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,6 +1,6 @@
+export { Platform } from "./Platform";
 export { Engine } from "./Engine";
 export { SystemInfo } from "./SystemInfo";
-export { Platform } from "./Platform";
 export type { Canvas } from "./Canvas";
 
 export { Scene } from "./Scene";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,6 @@
 export { Engine } from "./Engine";
 export { SystemInfo } from "./SystemInfo";
+export { Platform } from "./Platform";
 export type { Canvas } from "./Canvas";
 
 export { Scene } from "./Scene";

--- a/packages/rhi-webgl/src/WebGLEngine.ts
+++ b/packages/rhi-webgl/src/WebGLEngine.ts
@@ -17,7 +17,6 @@ export class WebGLEngine extends Engine {
     const webCanvas = new WebCanvas(
       <HTMLCanvasElement | OffscreenCanvas>(typeof canvas === "string" ? document.getElementById(canvas) : canvas)
     );
-
     const hardwareRenderer = new WebGLRenderer(webGLRendererOptions);
     super(webCanvas, hardwareRenderer);
   }

--- a/packages/rhi-webgl/src/WebGLEngine.ts
+++ b/packages/rhi-webgl/src/WebGLEngine.ts
@@ -1,6 +1,6 @@
-import { Engine } from "@oasis-engine/core";
+import { Engine, Platform, SystemInfo } from "@oasis-engine/core";
 import { WebCanvas } from "./WebCanvas";
-import { WebGLRenderer, WebGLRendererOptions } from "./WebGLRenderer";
+import { WebGLMode, WebGLRenderer, WebGLRendererOptions } from "./WebGLRenderer";
 
 type OffscreenCanvas = any;
 
@@ -17,6 +17,7 @@ export class WebGLEngine extends Engine {
     const webCanvas = new WebCanvas(
       <HTMLCanvasElement | OffscreenCanvas>(typeof canvas === "string" ? document.getElementById(canvas) : canvas)
     );
+
     const hardwareRenderer = new WebGLRenderer(webGLRendererOptions);
     super(webCanvas, hardwareRenderer);
   }

--- a/packages/rhi-webgl/src/WebGLEngine.ts
+++ b/packages/rhi-webgl/src/WebGLEngine.ts
@@ -1,6 +1,6 @@
-import { Engine, Platform, SystemInfo } from "@oasis-engine/core";
+import { Engine } from "@oasis-engine/core";
 import { WebCanvas } from "./WebCanvas";
-import { WebGLMode, WebGLRenderer, WebGLRendererOptions } from "./WebGLRenderer";
+import { WebGLRenderer, WebGLRendererOptions } from "./WebGLRenderer";
 
 type OffscreenCanvas = any;
 

--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -10,8 +10,10 @@ import {
   IPlatformTextureCube,
   Logger,
   Mesh,
+  Platform,
   RenderTarget,
   SubMesh,
+  SystemInfo,
   Texture2D,
   Texture2DArray,
   TextureCube
@@ -116,11 +118,21 @@ export class WebGLRenderer implements IHardwareRenderer {
     this._options = options;
   }
 
-  init(canvas: Canvas) {
+  init(canvas: Canvas):void {
+    debugger;
     const option = this._options;
     option.alpha === undefined && (option.alpha = false);
     option.stencil === undefined && (option.stencil = true);
-    option._forceFlush === undefined && (option._forceFlush = false);
+
+    if (SystemInfo.platform == Platform.IPhone || SystemInfo.platform == Platform.IPad) {
+      const version = SystemInfo.operatingSystem.split(".");
+      if (parseInt(version[1]) > 15 && parseInt(version[2]) >= 0 && parseInt(version[2]) <= 4) {
+        option._forceFlush = true;
+      }
+    } else {
+      option._forceFlush === undefined && (option._forceFlush = false);
+    }
+
     const webCanvas = (this._webCanvas = (canvas as WebCanvas)._webCanvas);
     const webGLMode = option.webGLMode || WebGLMode.Auto;
     let gl: (WebGLRenderingContext & WebGLExtension) | WebGL2RenderingContext;

--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -131,7 +131,6 @@ export class WebGLRenderer implements IHardwareRenderer {
   }
 
   init(canvas: Canvas): void {
-    debugger;
     const options = this._options;
     const webCanvas = (this._webCanvas = (canvas as WebCanvas)._webCanvas);
     const webGLMode = options.webGLMode;

--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -123,7 +123,9 @@ export class WebGLRenderer implements IHardwareRenderer {
 
     if (SystemInfo.platform === Platform.IPhone || SystemInfo.platform === Platform.IPad) {
       const version = SystemInfo.operatingSystem.match(/(\d+).(\d+).(\d+)/);
-      if (parseInt(version[1]) > 15 && parseInt(version[2]) >= 0 && parseInt(version[2]) <= 4) {
+      const majorVersion = parseInt(version[1]);
+      const minorVersion = parseInt(version[2]);
+      if (majorVersion === 15 && minorVersion >= 0 && minorVersion <= 4) {
         options._forceFlush = true;
       }
     }

--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -114,33 +114,33 @@ export class WebGLRenderer implements IHardwareRenderer {
     return this.capability.canIUseMoreJoints;
   }
 
-  constructor(options: WebGLRendererOptions = {}) {
+  constructor(initializeOptions: WebGLRendererOptions = {}) {
+    const options = <WebGLRendererOptions>{};
+    options.webGLMode = initializeOptions?.webGLMode ?? WebGLMode.Auto;
+    options.alpha = initializeOptions?.alpha ?? false;
+    options.stencil = initializeOptions?.stencil ?? true;
+    options._forceFlush = initializeOptions?._forceFlush ?? false;
+
+    if (SystemInfo.platform == Platform.IPhone || SystemInfo.platform == Platform.IPad) {
+      const version = SystemInfo.operatingSystem.match(/(\d+).(\d+).(\d+)/);
+      if (parseInt(version[1]) > 15 && parseInt(version[2]) >= 0 && parseInt(version[2]) <= 4) {
+        options._forceFlush = true;
+      }
+    }
     this._options = options;
   }
 
-  init(canvas: Canvas):void {
+  init(canvas: Canvas): void {
     debugger;
-    const option = this._options;
-    option.alpha === undefined && (option.alpha = false);
-    option.stencil === undefined && (option.stencil = true);
-
-    if (SystemInfo.platform == Platform.IPhone || SystemInfo.platform == Platform.IPad) {
-      const version = SystemInfo.operatingSystem.split(".");
-      if (parseInt(version[1]) > 15 && parseInt(version[2]) >= 0 && parseInt(version[2]) <= 4) {
-        option._forceFlush = true;
-      }
-    } else {
-      option._forceFlush === undefined && (option._forceFlush = false);
-    }
-
+    const options = this._options;
     const webCanvas = (this._webCanvas = (canvas as WebCanvas)._webCanvas);
-    const webGLMode = option.webGLMode || WebGLMode.Auto;
+    const webGLMode = options.webGLMode;
     let gl: (WebGLRenderingContext & WebGLExtension) | WebGL2RenderingContext;
 
     if (webGLMode == WebGLMode.Auto || webGLMode == WebGLMode.WebGL2) {
-      gl = webCanvas.getContext("webgl2", option);
+      gl = webCanvas.getContext("webgl2", options);
       if (!gl && (typeof OffscreenCanvas === "undefined" || !(webCanvas instanceof OffscreenCanvas))) {
-        gl = <WebGL2RenderingContext>webCanvas.getContext("experimental-webgl2", option);
+        gl = <WebGL2RenderingContext>webCanvas.getContext("experimental-webgl2", options);
       }
       this._isWebGL2 = true;
 
@@ -152,9 +152,9 @@ export class WebGLRenderer implements IHardwareRenderer {
 
     if (!gl) {
       if (webGLMode == WebGLMode.Auto || webGLMode == WebGLMode.WebGL1) {
-        gl = <WebGLRenderingContext & WebGLExtension>webCanvas.getContext("webgl", option);
+        gl = <WebGLRenderingContext & WebGLExtension>webCanvas.getContext("webgl", options);
         if (!gl && (typeof OffscreenCanvas === "undefined" || !(webCanvas instanceof OffscreenCanvas))) {
-          gl = <WebGLRenderingContext & WebGLExtension>webCanvas.getContext("experimental-webgl", option);
+          gl = <WebGLRenderingContext & WebGLExtension>webCanvas.getContext("experimental-webgl", options);
         }
         this._isWebGL2 = false;
       }

--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -121,7 +121,7 @@ export class WebGLRenderer implements IHardwareRenderer {
     options.stencil = initializeOptions?.stencil ?? true;
     options._forceFlush = initializeOptions?._forceFlush ?? false;
 
-    if (SystemInfo.platform == Platform.IPhone || SystemInfo.platform == Platform.IPad) {
+    if (SystemInfo.platform === Platform.IPhone || SystemInfo.platform === Platform.IPad) {
       const version = SystemInfo.operatingSystem.match(/(\d+).(\d+).(\d+)/);
       if (parseInt(version[1]) > 15 && parseInt(version[2]) >= 0 && parseInt(version[2]) <= 4) {
         options._forceFlush = true;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

Force flush command buffer in ipad OS/Iphone OS 15.0.x - 15.4.x
