### PR TITLE
Adjust canvas default  `alpha`

### DIFF
--- a/packages/rhi-webgl/src/WebGLRenderer.ts
+++ b/packages/rhi-webgl/src/WebGLRenderer.ts
@@ -117,7 +117,6 @@ export class WebGLRenderer implements IHardwareRenderer {
   constructor(initializeOptions: WebGLRendererOptions = {}) {
     const options = {
       webGLMode: WebGLMode.Auto,
-      alpha: false,
       stencil: true,
       _forceFlush: false,
       ...initializeOptions


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

relate issue: #1329 

With this PR https://github.com/ant-galaxy/oasis-engine/issues/1263, enable `alpha` is no more rendering exceptions, and can improve performance
