### PR TITLE
Fix animator not update when speed is 0

### DIFF
--- a/packages/core/src/animation/Animator.ts
+++ b/packages/core/src/animation/Animator.ts
@@ -23,12 +23,13 @@ import { KeyframeValueType } from "./Keyframe";
  */
 export class Animator extends Component {
   /** Culling mode of this Animator. */
-  public cullingMode: AnimatorCullingMode = AnimatorCullingMode.None;
+  cullingMode: AnimatorCullingMode = AnimatorCullingMode.None;
+  /** The playback speed of the Animator, 1.0 is normal playback speed. */
+  @assignmentClone
+  speed: number = 1.0;
 
   protected _animatorController: AnimatorController;
 
-  @assignmentClone
-  protected _speed: number = 1.0;
   @ignoreClone
   protected _controllerUpdateFlag: BoolUpdateFlag;
 
@@ -46,17 +47,6 @@ export class Animator extends Component {
 
   @ignoreClone
   private _controlledRenderers: Renderer[] = [];
-
-  /**
-   * The playback speed of the Animator, 1.0 is normal playback speed.
-   */
-  get speed(): number {
-    return this._speed;
-  }
-
-  set speed(value: number) {
-    this._speed = value;
-  }
 
   /**
    * All layers from the AnimatorController which belongs this Animator.
@@ -143,10 +133,6 @@ export class Animator extends Component {
    * @param deltaTime - The deltaTime when the animation update
    */
   update(deltaTime: number): void {
-    if (this.speed === 0) {
-      return;
-    }
-
     let animationUpdate: boolean;
     if (this.cullingMode === AnimatorCullingMode.Complete) {
       animationUpdate = false;
@@ -169,6 +155,7 @@ export class Animator extends Component {
       this._checkAutoPlay();
       return;
     }
+
     deltaTime *= this.speed;
     for (let i = 0, n = animatorController.layers.length; i < n; i++) {
       const animatorLayerData = this._getAnimatorLayerData(i);
@@ -473,7 +460,7 @@ export class Animator extends Component {
 
     for (let i = curveBindings.length - 1; i >= 0; i--) {
       const owner = curveOwners[i];
-      owner && owner.evaluateAndApplyValue(curveBindings[i].curve, clipTime, weight, additive);
+      owner?.evaluateAndApplyValue(curveBindings[i].curve, clipTime, weight, additive);
     }
 
     playData.frameTime += state.speed * delta;


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [x] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

When you want to "go and stop" , you need to do this before(#1217 ):
```ts
animator.play("A", 0, offsetTime);
animator.update(0);
animator.speed = 0;
```
And we must call  `animator.update(0);` before `animator.speed = 0;` this is very strange for the developer.
Even I think it's a bug.

The reason that causes this is that we stop internal update when speed is 0, and it is almost the same as `enbale == false`.

Two compelling reasons:
- The first instinct of `animator.speed = 0;` is just like pause and should work when  i switch another clip.(like we pause a video and drag the progress bar)
- 0 and 0.0000001 should not show a very noticeable difference

So I delete the optimization of stopping internal update when speed is 0, Now `go and stop` is just:
```ts
// maybe in editor or script, before can't in editor
animator.speed = 0;

// For always updating the animation manually, it is recommended that the editor set the speed to 0, just call play in script
animator.play("A", 0, offsetTime);
```



