### PR TITLE
Use swc es5 to improve compatibility

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -45,7 +45,8 @@ const commonPlugins = [
       exclude: /node_modules/,
       jsc: {
         loose: true,
-        externalHelpers: true
+        externalHelpers: true,
+        target: "es5"
       },
       sourceMaps: true
     })


### PR DESCRIPTION
Change target to es5 to maintain compatibility.