### PR TITLE
Move font map cache from `Font` to `Engine`

### DIFF
--- a/packages/core/src/2d/text/Font.ts
+++ b/packages/core/src/2d/text/Font.ts
@@ -7,8 +7,6 @@ import { SubFont } from "./SubFont";
  * Font.
  */
 export class Font extends RefObject {
-  private static _fontMap: Record<string, Font> = {};
-
   /**
    * Create a system font.
    * @param engine - Engine to which the font belongs
@@ -17,7 +15,7 @@ export class Font extends RefObject {
    */
   static createFromOS(engine: Engine, name: string): Font {
     if (name) {
-      const fontMap = Font._fontMap;
+      const fontMap = engine._fontMap;
       let font = fontMap[name];
       if (font) {
         return font;
@@ -68,6 +66,6 @@ export class Font extends RefObject {
       subFontMap[k].destroy();
     }
     this._subFontMap = null;
-    delete Font._fontMap[this._name];
+    delete this.engine._fontMap[this._name];
   }
 }

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -88,6 +88,8 @@ export class Engine extends EventDispatcher {
   _spriteMaskManager: SpriteMaskManager;
   /** @internal */
   _canSpriteBatch: boolean = true;
+  /** @internal */
+  _fontMap: Record<string, Font> = {};
   /** @internal @todo: temporary solution */
   _macroCollection: ShaderMacroCollection = new ShaderMacroCollection();
 
@@ -329,6 +331,12 @@ export class Engine extends EventDispatcher {
     this._magentaTexture2D.destroy(true);
     this._magentaTextureCube.destroy(true);
     this._textDefaultFont.destroy(true);
+
+    const fontMap = this._fontMap;
+    for (let k in fontMap) {
+      fontMap[k].destroy();
+    }
+    this._fontMap = null;
 
     this.inputManager._destroy();
     this.trigger(new Event("shutdown", this));

--- a/packages/core/src/Engine.ts
+++ b/packages/core/src/Engine.ts
@@ -330,12 +330,7 @@ export class Engine extends EventDispatcher {
     this._resourceManager._destroy();
     this._magentaTexture2D.destroy(true);
     this._magentaTextureCube.destroy(true);
-    this._textDefaultFont.destroy(true);
-
-    const fontMap = this._fontMap;
-    for (let k in fontMap) {
-      fontMap[k].destroy();
-    }
+    this._textDefaultFont = null;
     this._fontMap = null;
 
     this.inputManager._destroy();


### PR DESCRIPTION
### Please check if the PR fulfills these requirements

- [ ] The commit message follows our [guidelines](https://github.com/oasis-engine/engine/blob/main/.github/COMMIT_MESSAGE_CONVENTION.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

