### PR TITLE
Fix the default listener target for InputManager pointer

### DIFF
--- a/packages/core/src/input/keyboard/KeyboardManager.ts
+++ b/packages/core/src/input/keyboard/KeyboardManager.ts
@@ -74,6 +74,17 @@ export class KeyboardManager implements IInput {
             }
             curFrameUpList.add(codeKey);
             upKeyToFrameCountMap[codeKey] = frameCount;
+            // @todo
+            // Because on the mac, the keyup event is not responded to when the meta key is held down, 
+            // in order to maintain the correct keystroke record, it is necessary to clear the record 
+            // when the meta key is lifted.
+            // link: https://stackoverflow.com/questions/11818637/why-does-javascript-drop-keyup-events-when-the-metakey-is-pressed-on-mac-browser
+            // if (codeKey === Keys.MetaLeft || codeKey === Keys.MetaRight) {
+            //   for (let i = 0, len = curFrameHeldDownList.length; i < len; i++) {
+            //     curHeldDownKeyToIndexMap[curFrameHeldDownList.get(i)] = null;
+            //   }
+            //   curFrameHeldDownList.length = 0;
+            // }
             break;
           default:
             break;

--- a/packages/core/src/input/pointer/PointerManager.ts
+++ b/packages/core/src/input/pointer/PointerManager.ts
@@ -112,10 +112,10 @@ export class PointerManager implements IInput {
     if (!this._hadListener) {
       const { _htmlCanvas: htmlCanvas, _onPointerEvent: onPointerEvent } = this;
       htmlCanvas.addEventListener("pointerdown", onPointerEvent);
-      htmlCanvas.addEventListener("pointerup", onPointerEvent);
-      htmlCanvas.addEventListener("pointerout", onPointerEvent);
-      htmlCanvas.addEventListener("pointermove", onPointerEvent);
-      htmlCanvas.addEventListener("pointercancel", onPointerEvent);
+      document.addEventListener("pointermove", onPointerEvent);
+      document.addEventListener("pointerup", onPointerEvent);
+      document.addEventListener("pointerleave", onPointerEvent);
+      document.addEventListener("pointercancel", onPointerEvent);
       this._hadListener = true;
     }
   }
@@ -127,10 +127,10 @@ export class PointerManager implements IInput {
     if (this._hadListener) {
       const { _htmlCanvas: htmlCanvas, _onPointerEvent: onPointerEvent } = this;
       htmlCanvas.removeEventListener("pointerdown", onPointerEvent);
-      htmlCanvas.removeEventListener("pointerup", onPointerEvent);
-      htmlCanvas.removeEventListener("pointerout", onPointerEvent);
-      htmlCanvas.removeEventListener("pointermove", onPointerEvent);
-      htmlCanvas.removeEventListener("pointercancel", onPointerEvent);
+      document.removeEventListener("pointermove", onPointerEvent);
+      document.removeEventListener("pointerup", onPointerEvent);
+      document.removeEventListener("pointerleave", onPointerEvent);
+      document.removeEventListener("pointercancel", onPointerEvent);
       this._hadListener = false;
       this._downList.length = 0;
       this._upList.length = 0;
@@ -150,10 +150,10 @@ export class PointerManager implements IInput {
     if (this._hadListener) {
       const { _htmlCanvas: htmlCanvas, _onPointerEvent: onPointerEvent } = this;
       htmlCanvas.removeEventListener("pointerdown", onPointerEvent);
-      htmlCanvas.removeEventListener("pointerup", onPointerEvent);
-      htmlCanvas.removeEventListener("pointerout", onPointerEvent);
-      htmlCanvas.removeEventListener("pointermove", onPointerEvent);
-      htmlCanvas.removeEventListener("pointercancel", onPointerEvent);
+      document.removeEventListener("pointermove", onPointerEvent);
+      document.removeEventListener("pointerup", onPointerEvent);
+      document.removeEventListener("pointerleave", onPointerEvent);
+      document.removeEventListener("pointercancel", onPointerEvent);
       this._hadListener = false;
     }
     this._pointerPool.length = 0;
@@ -287,7 +287,7 @@ export class PointerManager implements IInput {
             pointer.phase = PointerPhase.Up;
             pointer._firePointerUpAndClick(rayCastEntity);
             break;
-          case "pointerout":
+          case "pointerleave":
           case "pointercancel":
             pointer.phase = PointerPhase.Leave;
             pointer._firePointerExitAndEnter(null);
@@ -345,7 +345,7 @@ export class PointerManager implements IInput {
           case "pointermove":
             pointer.phase = PointerPhase.Move;
             break;
-          case "pointerout":
+          case "pointerleave":
           case "pointercancel":
             pointer.phase = PointerPhase.Leave;
           default:


### PR DESCRIPTION
Supports receiving global movement events when operating in the editor.