### PR TITLE
Adjust script `onCollisionXX` callback parameters

### DIFF
--- a/packages/core/src/Script.ts
+++ b/packages/core/src/Script.ts
@@ -86,36 +86,36 @@ export class Script extends Component {
   onTriggerEnter(other: ColliderShape): void {}
 
   /**
-   * Called when the trigger stay.
-   * @remarks onTriggerStay is called every frame while the trigger stay.
+   * Called when the trigger exit.
    * @param other - ColliderShape
    */
   onTriggerExit(other: ColliderShape): void {}
 
   /**
-   * Called when the trigger exit.
+   * Called when the trigger stay.
+   * @remarks onTriggerStay is called every frame while the trigger stay.
    * @param other - ColliderShape
    */
   onTriggerStay(other: ColliderShape): void {}
 
   /**
    * Called when the collision enter.
-   * @param other - The Collision data associated with this collision event.
-   * @remark The Collision data will be invalid after this call, you should copy the data if needed
+   * @param other - The Collision data associated with this collision event
+   * @remarks The Collision data will be invalid after this call, you should copy the data if needed.
    */
   onCollisionEnter(other: Collision): void {}
 
   /**
-   * Called when the collision stay.
-   * @param other - The Collision data associated with this collision event.
-   * @remark The Collision data will be invalid after this call, you should copy the data if needed
+   * Called when the collision exit.
+   * @param other - The Collision data associated with this collision event
+   * @remarks The Collision data will be invalid after this call, you should copy the data if needed.
    */
   onCollisionExit(other: Collision): void {}
 
   /**
-   * Called when the collision exit.
-   * @param other - The Collision data associated with this collision event.
-   * @remark The Collision data will be invalid after this call, you should copy the data if needed
+   * Called when the collision stay.
+   * @param other - The Collision data associated with this collision event
+   * @remarks The Collision data will be invalid after this call, you should copy the data if needed.
    */
   onCollisionStay(other: Collision): void {}
 

--- a/packages/core/src/Script.ts
+++ b/packages/core/src/Script.ts
@@ -3,6 +3,7 @@ import { ignoreClone } from "./clone/CloneManager";
 import { Component } from "./Component";
 import { Pointer } from "./input";
 import { ColliderShape } from "./physics";
+import { Collision } from "./physics/Collision";
 
 /**
  * Script class, used for logic writing.
@@ -79,42 +80,44 @@ export class Script extends Component {
   onPhysicsUpdate(): void {}
 
   /**
-   * Called when the collision enter.
+   * Called when the trigger enter.
    * @param other - ColliderShape
    */
   onTriggerEnter(other: ColliderShape): void {}
 
   /**
-   * Called when the collision stay.
-   * @remarks onTriggerStay is called every frame while the collision stay.
+   * Called when the trigger stay.
+   * @remarks onTriggerStay is called every frame while the trigger stay.
    * @param other - ColliderShape
    */
   onTriggerExit(other: ColliderShape): void {}
 
   /**
-   * Called when the collision exit.
+   * Called when the trigger exit.
    * @param other - ColliderShape
    */
   onTriggerStay(other: ColliderShape): void {}
 
   /**
    * Called when the collision enter.
-   * @param other - ColliderShape
+   * @param other - The Collision data associated with this collision event.
+   * @remark The Collision data will be invalid after this call, you should copy the data if needed
    */
-  onCollisionEnter(other: ColliderShape): void {}
+  onCollisionEnter(other: Collision): void {}
 
   /**
    * Called when the collision stay.
-   * @remarks onTriggerStay is called every frame while the collision stay.
-   * @param other - ColliderShape
+   * @param other - The Collision data associated with this collision event.
+   * @remark The Collision data will be invalid after this call, you should copy the data if needed
    */
-  onCollisionExit(other: ColliderShape): void {}
+  onCollisionExit(other: Collision): void {}
 
   /**
    * Called when the collision exit.
-   * @param other - ColliderShape
+   * @param other - The Collision data associated with this collision event.
+   * @remark The Collision data will be invalid after this call, you should copy the data if needed
    */
-  onCollisionStay(other: ColliderShape): void {}
+  onCollisionStay(other: Collision): void {}
 
   /**
    * Called when the pointer is down while over the ColliderShape.

--- a/packages/core/src/physics/Collision.ts
+++ b/packages/core/src/physics/Collision.ts
@@ -1,0 +1,5 @@
+import { ColliderShape } from "./shape";
+
+export class Collision {
+  shape: ColliderShape;
+}

--- a/packages/core/src/physics/PhysicsManager.ts
+++ b/packages/core/src/physics/PhysicsManager.ts
@@ -7,11 +7,14 @@ import { CharacterController } from "./CharacterController";
 import { Collider } from "./Collider";
 import { HitResult } from "./HitResult";
 import { ColliderShape } from "./shape";
+import { Collision } from "./Collision";
 
 /**
  * A physics manager is a collection of colliders and constraints which can interact.
  */
 export class PhysicsManager {
+  private static _collision = new Collision();
+
   /** @internal */
   static _nativePhysics: IPhysics;
   /** @internal */
@@ -32,13 +35,21 @@ export class PhysicsManager {
     let scripts = shape1.collider.entity._scripts;
     for (let i = 0, len = scripts.length; i < len; i++) {
       const script = scripts.get(i);
-      script._waitHandlingInValid || script.onCollisionEnter(shape2);
+      if (!script._waitHandlingInValid) {
+        let collision = PhysicsManager._collision;
+        collision.shape = shape2;
+        script.onCollisionEnter(collision);
+      }
     }
 
     scripts = shape2.collider.entity._scripts;
     for (let i = 0, len = scripts.length; i < len; i++) {
       const script = scripts.get(i);
-      script._waitHandlingInValid || script.onCollisionEnter(shape1);
+      if (!script._waitHandlingInValid) {
+        let collision = PhysicsManager._collision;
+        collision.shape = shape1;
+        script.onCollisionEnter(collision);
+      }
     }
   };
   private _onContactExit = (obj1: number, obj2: number) => {
@@ -48,13 +59,21 @@ export class PhysicsManager {
     let scripts = shape1.collider.entity._scripts;
     for (let i = 0, len = scripts.length; i < len; i++) {
       const script = scripts.get(i);
-      script._waitHandlingInValid || script.onCollisionExit(shape2);
+      if (!script._waitHandlingInValid) {
+        let collision = PhysicsManager._collision;
+        collision.shape = shape2;
+        script.onCollisionExit(collision);
+      }
     }
 
     scripts = shape2.collider.entity._scripts;
     for (let i = 0, len = scripts.length; i < len; i++) {
       const script = scripts.get(i);
-      script._waitHandlingInValid || script.onCollisionExit(shape1);
+      if (!script._waitHandlingInValid) {
+        let collision = PhysicsManager._collision;
+        collision.shape = shape1;
+        script.onCollisionExit(collision);
+      }
     }
   };
   private _onContactStay = (obj1: number, obj2: number) => {
@@ -64,13 +83,21 @@ export class PhysicsManager {
     let scripts = shape1.collider.entity._scripts;
     for (let i = 0, len = scripts.length; i < len; i++) {
       const script = scripts.get(i);
-      script._waitHandlingInValid || script.onCollisionStay(shape2);
+      if (!script._waitHandlingInValid) {
+        let collision = PhysicsManager._collision;
+        collision.shape = shape2;
+        script.onCollisionStay(collision);
+      }
     }
 
     scripts = shape2.collider.entity._scripts;
     for (let i = 0, len = scripts.length; i < len; i++) {
       const script = scripts.get(i);
-      script._waitHandlingInValid || script.onCollisionStay(shape1);
+      if (!script._waitHandlingInValid) {
+        let collision = PhysicsManager._collision;
+        collision.shape = shape1;
+        script.onCollisionStay(collision);
+      }
     }
   };
   private _onTriggerEnter = (obj1: number, obj2: number) => {

--- a/packages/physics-physx/src/PhysXCharacterController.ts
+++ b/packages/physics-physx/src/PhysXCharacterController.ts
@@ -114,7 +114,7 @@ export class PhysXCharacterController implements ICharacterController {
     desc.setMaterial(shape._pxMaterials[0]);
 
     this._pxController = pxManager._getControllerManager().createController(desc);
-    this._pxController.setQueryFilterData(new PhysXPhysics._physX.PxFilterData(shape._id, 0, 0, 0));
+    this._pxController.setUUID(shape._id);
   }
 
   /**

--- a/packages/physics-physx/src/PhysXPhysics.ts
+++ b/packages/physics-physx/src/PhysXPhysics.ts
@@ -100,8 +100,9 @@ export class PhysXPhysics {
    * Destroy PhysXPhysics.
    */
   public static destroy(): void {
-    this._pxFoundation.release();
+    this._physX.PxCloseExtensions();
     this._pxPhysics.release();
+    this._pxFoundation.release();
     this._physX = null;
     this._pxFoundation = null;
     this._pxPhysics = null;

--- a/packages/physics-physx/src/PhysXPhysicsManager.ts
+++ b/packages/physics-physx/src/PhysXPhysicsManager.ts
@@ -148,7 +148,6 @@ export class PhysXPhysicsManager implements IPhysicsManager {
         lastPXManager && characterController._destroyPXController();
         characterController._createPXController(this, shape);
       }
-      this._pxScene.addController(characterController._pxController);
     }
     characterController._pxManager = this;
   }
@@ -157,9 +156,7 @@ export class PhysXPhysicsManager implements IPhysicsManager {
    * {@inheritDoc IPhysicsManager.removeCharacterController }
    */
   removeCharacterController(characterController: PhysXCharacterController): void {
-    if (characterController._shape) {
-      this._pxScene.removeController(characterController._pxController);
-    }
+    characterController._pxController = null;
     characterController._pxManager = null;
   }
 

--- a/packages/physics-physx/src/PhysXPhysicsManager.ts
+++ b/packages/physics-physx/src/PhysXPhysicsManager.ts
@@ -55,31 +55,21 @@ export class PhysXPhysicsManager implements IPhysicsManager {
     this._onTriggerStay = onTriggerStay;
 
     const triggerCallback = {
-      onContactBegin: (obj1, obj2) => {
-        const index1 = obj1.getQueryFilterData().word0;
-        const index2 = obj2.getQueryFilterData().word0;
+      onContactBegin: (index1, index2) => {
         this._onContactEnter(index1, index2);
       },
-      onContactEnd: (obj1, obj2) => {
-        const index1 = obj1.getQueryFilterData().word0;
-        const index2 = obj2.getQueryFilterData().word0;
+      onContactEnd: (index1, index2) => {
         this._onContactExit(index1, index2);
       },
-      onContactPersist: (obj1, obj2) => {
-        const index1 = obj1.getQueryFilterData().word0;
-        const index2 = obj2.getQueryFilterData().word0;
+      onContactPersist: (index1, index2) => {
         this._onContactStay(index1, index2);
       },
-      onTriggerBegin: (obj1, obj2) => {
-        const index1 = obj1.getQueryFilterData().word0;
-        const index2 = obj2.getQueryFilterData().word0;
+      onTriggerBegin: (index1, index2) => {
         const event = index1 < index2 ? this._getTrigger(index1, index2) : this._getTrigger(index2, index1);
         event.state = TriggerEventState.Enter;
         this._currentEvents.add(event);
       },
-      onTriggerEnd: (obj1, obj2) => {
-        const index1 = obj1.getQueryFilterData().word0;
-        const index2 = obj2.getQueryFilterData().word0;
+      onTriggerEnd: (index1, index2) => {
         let event: TriggerEvent;
         if (index1 < index2) {
           const subMap = this._eventMap[index1];
@@ -195,8 +185,7 @@ export class PhysXPhysicsManager implements IPhysicsManager {
     distance = Math.min(distance, 3.4e38); // float32 max value limit in physx raycast.
 
     const raycastCallback = {
-      preFilter: (filterData, shape, actor) => {
-        const index = shape.getQueryFilterData().word0;
+      preFilter: (filterData, index, actor) => {
         if (onRaycast(index)) {
           return 2; // eBLOCK
         } else {
@@ -221,7 +210,7 @@ export class PhysXPhysicsManager implements IPhysicsManager {
       position.set(pxPosition.x, pxPosition.y, pxPosition.z);
       normal.set(pxNormal.x, pxNormal.y, pxNormal.z);
 
-      hit(pxHitResult.getShape().getQueryFilterData().word0, pxHitResult.distance, position, normal);
+      hit(pxHitResult.getShape().getUUID(), pxHitResult.distance, position, normal);
     }
     return result;
   }

--- a/packages/physics-physx/src/shape/PhysXColliderShape.ts
+++ b/packages/physics-physx/src/shape/PhysXColliderShape.ts
@@ -134,7 +134,7 @@ export abstract class PhysXColliderShape implements IColliderShape {
       true,
       new PhysXPhysics._physX.PxShapeFlags(this._shapeFlags)
     );
-    this._pxShape.setQueryFilterData(new PhysXPhysics._physX.PxFilterData(id, 0, 0, 0));
+    this._pxShape.setUUID(id);
   }
 
   private _modifyFlag(flag: ShapeFlag, value: boolean): void {


### PR DESCRIPTION
There are multipy enhance for physx binding:
1. use userdata in shape instead of PXFilterData to store shape id, otherwise the PXFilterData will be used in CollisionGroup enable/disable.
2. add collison class to store collidershape which will add more information about collision in the future
3. add CloseExtension when release whole physx package
4. should not add character controller into scene, CharacterControllerMananger already do this! if we add into scene, when it will cause problem when release