### PR TITLE
Fix SpriteRenderer bounding box error

### DIFF
--- a/packages/core/src/2d/sprite/Sprite.ts
+++ b/packages/core/src/2d/sprite/Sprite.ts
@@ -47,6 +47,7 @@ export class Sprite extends RefObject {
     if (this._texture !== value) {
       this._texture = value;
       this._dispatchSpriteChange(SpriteModifyFlags.texture);
+      (this._width === undefined || this.height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
     }
   }
 
@@ -105,6 +106,7 @@ export class Sprite extends RefObject {
     const y = MathUtil.clamp(value.y, 0, 1);
     this._atlasRegion.set(x, y, MathUtil.clamp(value.width, 0, 1 - x), MathUtil.clamp(value.height, 0, 1 - y));
     this._dispatchSpriteChange(SpriteModifyFlags.atlasRegion);
+    (this._width === undefined || this.height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
   }
 
   /**
@@ -119,6 +121,7 @@ export class Sprite extends RefObject {
     const y = MathUtil.clamp(value.y, 0, 1);
     this._atlasRegionOffset.set(x, y, MathUtil.clamp(value.z, 0, 1 - x), MathUtil.clamp(value.w, 0, 1 - y));
     this._dispatchSpriteChange(SpriteModifyFlags.atlasRegionOffset);
+    (this._width === undefined || this.height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
   }
 
   /**
@@ -134,6 +137,7 @@ export class Sprite extends RefObject {
     const y = MathUtil.clamp(value.y, 0, 1);
     region.set(x, y, MathUtil.clamp(value.width, 0, 1 - x), MathUtil.clamp(value.height, 0, 1 - y));
     this._dispatchSpriteChange(SpriteModifyFlags.region);
+    (this._width === undefined || this.height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
   }
 
   /**
@@ -251,11 +255,11 @@ export class Sprite extends RefObject {
     if (this._texture) {
       const { _texture, _atlasRegion, _atlasRegionOffset, _region } = this;
       const pixelsPerUnitReciprocal = 1.0 / Engine._pixelsPerUnit;
-      this.width =
+      this._width =
         ((_texture.width * _atlasRegion.width) / (1 - _atlasRegionOffset.x - _atlasRegionOffset.z)) *
         _region.width *
         pixelsPerUnitReciprocal;
-      this.height =
+      this._height =
         ((_texture.height * _atlasRegion.height) / (1 - _atlasRegionOffset.y - _atlasRegionOffset.w)) *
         _region.height *
         pixelsPerUnitReciprocal;

--- a/packages/core/src/2d/sprite/Sprite.ts
+++ b/packages/core/src/2d/sprite/Sprite.ts
@@ -47,7 +47,7 @@ export class Sprite extends RefObject {
     if (this._texture !== value) {
       this._texture = value;
       this._dispatchSpriteChange(SpriteModifyFlags.texture);
-      (this._width === undefined || this.height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
+      (this._width === undefined || this._height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
     }
   }
 
@@ -106,7 +106,7 @@ export class Sprite extends RefObject {
     const y = MathUtil.clamp(value.y, 0, 1);
     this._atlasRegion.set(x, y, MathUtil.clamp(value.width, 0, 1 - x), MathUtil.clamp(value.height, 0, 1 - y));
     this._dispatchSpriteChange(SpriteModifyFlags.atlasRegion);
-    (this._width === undefined || this.height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
+    (this._width === undefined || this._height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
   }
 
   /**
@@ -121,7 +121,7 @@ export class Sprite extends RefObject {
     const y = MathUtil.clamp(value.y, 0, 1);
     this._atlasRegionOffset.set(x, y, MathUtil.clamp(value.z, 0, 1 - x), MathUtil.clamp(value.w, 0, 1 - y));
     this._dispatchSpriteChange(SpriteModifyFlags.atlasRegionOffset);
-    (this._width === undefined || this.height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
+    (this._width === undefined || this._height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
   }
 
   /**
@@ -137,7 +137,7 @@ export class Sprite extends RefObject {
     const y = MathUtil.clamp(value.y, 0, 1);
     region.set(x, y, MathUtil.clamp(value.width, 0, 1 - x), MathUtil.clamp(value.height, 0, 1 - y));
     this._dispatchSpriteChange(SpriteModifyFlags.region);
-    (this._width === undefined || this.height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
+    (this._width === undefined || this._height === undefined) && this._dispatchSpriteChange(SpriteModifyFlags.size);
   }
 
   /**

--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -117,13 +117,13 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
    * Render width.
    */
   get width(): number {
-    if (this._width === undefined && this._sprite) {
-      this.width = this._sprite.width;
-    }
+    this._width === undefined && this._sprite && (this.width = this._sprite.width);
     return this._width;
   }
 
   set width(value: number) {
+    // Update width if undefined
+    this._width === undefined && this._sprite && (this._width = this._sprite.width);
     if (this._width !== value) {
       this._width = value;
       this._dirtyUpdateFlag |= RendererUpdateFlags.WorldVolume;
@@ -134,13 +134,13 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
    * Render height.
    */
   get height(): number {
-    if (this._height === undefined && this._sprite) {
-      this.height = this._sprite.height;
-    }
+    this._height === undefined && this._sprite && (this.height = this._sprite.height);
     return this._height;
   }
 
   set height(value: number) {
+    // Update height if undefined
+    this._height === undefined && this._sprite && (this._height = this._sprite.height);
     if (this._height !== value) {
       this._height = value;
       this._dirtyUpdateFlag |= RendererUpdateFlags.WorldVolume;
@@ -234,6 +234,7 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
    * @override
    */
   protected _updateBounds(worldBounds: BoundingBox): void {
+    console.log("_updateBounds");
     if (!this.sprite?.texture || !this.width || !this.height) {
       worldBounds.min.set(0, 0, 0);
       worldBounds.max.set(0, 0, 0);

--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -234,7 +234,6 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
    * @override
    */
   protected _updateBounds(worldBounds: BoundingBox): void {
-    console.log("_updateBounds");
     if (!this.sprite?.texture || !this.width || !this.height) {
       worldBounds.min.set(0, 0, 0);
       worldBounds.max.set(0, 0, 0);

--- a/packages/core/src/2d/sprite/SpriteRenderer.ts
+++ b/packages/core/src/2d/sprite/SpriteRenderer.ts
@@ -304,7 +304,11 @@ export class SpriteRenderer extends Renderer implements ICustomClone {
         this.shaderData.setTexture(SpriteRenderer._textureProperty, this.sprite.texture);
         break;
       case SpriteModifyFlags.size:
-        this._drawMode === SpriteDrawMode.Sliced && (this._dirtyUpdateFlag |= RendererUpdateFlags.WorldVolume);
+        // When the width and height of `SpriteRenderer` are `undefined`,
+        // the `size` of `Sprite` will affect the position of `SpriteRenderer`.
+        if (this._drawMode === SpriteDrawMode.Sliced || this._width === undefined || this._height === undefined) {
+          this._dirtyUpdateFlag |= RendererUpdateFlags.WorldVolume;
+        }
         break;
       case SpriteModifyFlags.border:
         this._drawMode === SpriteDrawMode.Sliced && (this._dirtyUpdateFlag |= SpriteRendererUpdateFlags.All);


### PR DESCRIPTION
When the width and height of `SpriteRenderer` are `undefined`, the texture of `Sprite` will affect the position of `SpriteRenderer`.