### PR TITLE
Fix scene parser error

### DIFF
--- a/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
+++ b/packages/loader/src/resource-deserialize/resources/scene/SceneParser.ts
@@ -82,7 +82,7 @@ export class SceneParser {
     }
   }
 
-  private _parseComponents() {
+  private _parseComponents(): Promise<any[]> {
     const entitiesConfig = this.context.originalData.entities;
     const entityMap = this.context.entityMap;
 
@@ -103,6 +103,7 @@ export class SceneParser {
         promises.push(promise);
       }
     }
+    return Promise.all(promises);
   }
 
   private _clearAndResolveScene() {


### PR DESCRIPTION
As developers we usually think:
```
engine.resourceManager.load<Scene>( { url: XXX,  type: XXX } ).then(()=>{
      // At this time we think the scene should have been initialized.
})
```
But after the scene is loaded, some properties are not initialized.(Like `_parseComponents`)

